### PR TITLE
Deprecate DependencyInjectionNodeObserver, create DependencyInjection ManagerNode and IServicesConfigurator

### DIFF
--- a/Godot.DependencyInjection/DependencyInjectionManagerNode.cs
+++ b/Godot.DependencyInjection/DependencyInjectionManagerNode.cs
@@ -1,0 +1,77 @@
+﻿using Godot.DependencyInjection.Exceptions;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Godot.DependencyInjection
+{
+    public abstract partial class DependencyInjectionManagerNode : Node
+    {
+        private InjectionService _injectionService = null!;
+
+        /// <summary>
+        /// Called when the node is ready.
+        /// </summary>
+        public override void _Ready()
+        {
+            var tree = GetTree();
+            var nodeLists = ProcessInitialNodes(tree);
+            ServiceProvider serviceProvider = BuildServiceProvider(nodeLists.configurators);
+            _injectionService = new InjectionService(serviceProvider);
+
+            foreach (var node in nodeLists.nodesToInject)
+            {
+                _injectionService.InjectDependencies(node);
+            }
+
+            tree.NodeAdded += _injectionService.InjectDependencies;
+        }
+
+        /// <summary>
+        /// Registers services from nodes implementing <see cref="IServicesConfigurator"/>
+        /// </summary>
+        /// <param name="configurators"></param>
+        /// <returns></returns>
+        private static ServiceProvider BuildServiceProvider(List<IServicesConfigurator> configurators)
+        {
+            ServiceCollection services = new();
+            foreach (var item in configurators)
+            {
+                item.ConfigureServices(services);
+            }
+            var serviceProvider = services.BuildServiceProvider();
+            return serviceProvider;
+        }
+
+        /// <summary>
+        /// Processes the initial nodes in the scene tree.
+        /// </summary>
+        /// <param name="tree">The scene tree to process.</param>
+        private (List<Node> nodesToInject, List<IServicesConfigurator> configurators) ProcessInitialNodes(SceneTree tree)
+        {
+            var nodesToInject = new List<Node>();
+            var configurators = new List<IServicesConfigurator>();
+            var queue = new Queue<Node>();
+            queue.Enqueue(tree.Root);
+
+            while (queue.TryDequeue(out var element))
+            {
+                nodesToInject.Add(element);
+                if (element is IServicesConfigurator servicesConfigurator)
+                {
+                    configurators.Add(servicesConfigurator);
+                }
+
+                var children = element.GetChildren(true);
+                foreach (var child in children)
+                {
+                    queue.Enqueue(child);
+                }
+            }
+            return (nodesToInject: nodesToInject, configurators: configurators);
+        }
+    }
+}

--- a/Godot.DependencyInjection/DependencyInjectionNodeObserver.cs
+++ b/Godot.DependencyInjection/DependencyInjectionNodeObserver.cs
@@ -5,65 +5,18 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Godot.DependencyInjection;
 
 /// <summary>
+/// Deprecated,use <see cref="DependencyInjectionManagerNode"/>
 /// Represents an observer that handles dependency injection for Godot nodes.
 /// </summary>
 [IgnoreDependencyInjection]
-public abstract partial class DependencyInjectionNodeObserver : Node
+[Obsolete("Use DependencyInjectionManagerNode instead of this class")]
+public abstract partial class DependencyInjectionNodeObserver : DependencyInjectionManagerNode, IServicesConfigurator
 {
-    private static bool _isInstantiated;
-    private readonly InjectionService _injectionService;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DependencyInjectionNodeObserver"/> class.
-    /// </summary>
-    public DependencyInjectionNodeObserver()
-    {
-        DependencyInjectionObserverDuplicationException.ThrowIf(_isInstantiated);
-
-        ServiceCollection services = new();
-        ConfigureServices(services);
-
-        var serviceProvider = services.BuildServiceProvider();
-
-        _injectionService = new InjectionService(serviceProvider);
-
-        _isInstantiated = true;
-    }
-
-    /// <summary>
-    /// Configures the services to be used in the dependency injection container.
-    /// </summary>
-    /// <param name="services">The service collection to add services to.</param>
+    
+    /// <inheritdoc/>
     public abstract void ConfigureServices(IServiceCollection services);
 
-    /// <summary>
-    /// Called when the node is ready.
-    /// </summary>
-    public override void _Ready()
-    {
-        var tree = GetTree();
-        ProcessInitialNodes(tree);
-        tree.NodeAdded += _injectionService.InjectDependencies;
-    }
-
-    /// <summary>
-    /// Processes the initial nodes in the scene tree.
-    /// </summary>
-    /// <param name="tree">The scene tree to process.</param>
-    private void ProcessInitialNodes(SceneTree tree)
-    {
-        var queue = new Queue<Node>();
-        queue.Enqueue(tree.Root);
-
-        while (queue.TryDequeue(out var element))
-        {
-            _injectionService.InjectDependencies(element);
-
-            var children = element.GetChildren(true);
-            foreach (var child in children)
-            {
-                queue.Enqueue(child);
-            }
-        }
-    }
 }
+
+

--- a/Godot.DependencyInjection/Godot.DependencyInjection.csproj
+++ b/Godot.DependencyInjection/Godot.DependencyInjection.csproj
@@ -10,7 +10,7 @@
 	<PropertyGroup>
 		<Title>Godot.DependencyInjection</Title>
 		<RepositoryUrl>https://github.com/Filip-Drabinski/Godot.DependencyInjection</RepositoryUrl>
-		<VersionPrefix>0.1.0</VersionPrefix>
+		<VersionPrefix>0.2.0</VersionPrefix>
 		<Description>Godot.DependencyInjection is a lightweight and easy-to-use dependency injection framework for the Godot game engine, specifically tailored for C#. It aims to help developers create more modular, testable, and maintainable game projects using the Godot engine.</Description>
 		<PackageProjectUrl>https://github.com/Filip-Drabinski/Godot.DependencyInjection</PackageProjectUrl>
 		<RepositoryType></RepositoryType>

--- a/Godot.DependencyInjection/IServicesConfigurator.cs
+++ b/Godot.DependencyInjection/IServicesConfigurator.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Godot.DependencyInjection
+{
+    public interface IServicesConfigurator
+    {
+        /// <summary>
+        /// Configures the services to be used in the dependency injection container.
+        /// </summary>
+        /// <param name="services">The service collection to add services to.</param>
+        void ConfigureServices(IServiceCollection services);
+    }
+}


### PR DESCRIPTION
Deprecates the 'DependencyInjectionNodeObserver' class and introduces the 'DependencyInjectionManagerNode' class and 'IServicesConfigurator' interface. This change splits the role of the 'DependencyInjectionNodeObserver' into two separate components: the 'DependencyInjectionManagerNode' class for managing dependency injection, and the 'IServicesConfigurator' interface for registering services. From now on, dependencies will be registered using all classes implementing the 'IServicesConfigurator' interface with instances in the scene tree at the moment of scene creation.