### PR TITLE
Update onboarding instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ public partial class RegularNode : Node2D
     }
     ```
 2. Add the script to Project -> Project Settings -> Autoload.
-3. Create a node and script for dependency registration:
+3. Create a `Node` and script for dependency registration:
     ```csharp
-    public partial class DependencyRegistrationNode : IServicesConfigurator
+    public partial class DependencyRegistrationNode : Node, IServicesConfigurator
     {
-        public override void ConfigureServices(IServiceCollection services)
+        public void ConfigureServices(IServiceCollection services)
         {
             services.AddGodotServices();
             services.AddTransient<IService, Service>();


### PR DESCRIPTION
Ran into a bit of issues with the example code:

1) Not an `override` as its an interface.
2) Godot wouldn't initialize the script/node as it didn't inherit from `Node` when the script was attached to the node. Unless I'm misunderstanding a different way to add the node, but that's the only way I know at the moment is via attaching.