### PR TITLE
Make private methods also affected by the inject attribute.

### DIFF
--- a/Godot.DependencyInjection.Core/Scanning/InjectableScanner.cs
+++ b/Godot.DependencyInjection.Core/Scanning/InjectableScanner.cs
@@ -32,7 +32,7 @@ internal static partial class InjectionScanner
 
     private static InjectionMetadata? ProcessType(Type type)
     {
-        var methods = type.GetMethods();
+        var methods = type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic);
         var properties = type.GetProperties();
         var fields = type.GetFields();
 

--- a/Godot.DependencyInjection.Core/Scanning/InjectableScanner.cs
+++ b/Godot.DependencyInjection.Core/Scanning/InjectableScanner.cs
@@ -32,7 +32,7 @@ internal static partial class InjectionScanner
 
     private static InjectionMetadata? ProcessType(Type type)
     {
-        var methods = type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic);
+        var methods = type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
         var properties = type.GetProperties();
         var fields = type.GetFields();
 


### PR DESCRIPTION
Made it possible to get NonPublic Method in type.GetMethods().