### PR TITLE
It was not possible to inject a Service and also inject Members of this Service.

### DIFF
--- a/Godot.DependencyInjection.Core.UnitTests.FirstAssemblyToScan/FirstAssembly1.cs
+++ b/Godot.DependencyInjection.Core.UnitTests.FirstAssemblyToScan/FirstAssembly1.cs
@@ -11,8 +11,9 @@ public class FirstAssembly1
 {
     [Inject]
     public Guid GuidPublic { get; set; }
-    [InjectMembers]
-    public FirstAssembly2 FirstAssembly2Public { get; set; } = null!;
+
+    [Inject, InjectMembers]
+    public FirstAssembly2 FirstAssembly2Public;
 
     [Inject]
     protected Guid GuidProtected { get; set; }

--- a/Godot.DependencyInjection.Core.UnitTests.FirstAssemblyToScan/FirstAssembly1.cs
+++ b/Godot.DependencyInjection.Core.UnitTests.FirstAssemblyToScan/FirstAssembly1.cs
@@ -17,9 +17,9 @@ public class FirstAssembly1
 
     [Inject]
     protected Guid GuidProtected { get; set; }
+    
     [InjectMembers]
     protected FirstAssembly2 FirstAssembly2Protected { get; set; } = null!;
-    [InjectMembers]
 
     [Inject]
     private Guid GuidPrivate { get; set; }

--- a/Godot.DependencyInjection.Core.UnitTests/InjectionScannerUnitTest.cs
+++ b/Godot.DependencyInjection.Core.UnitTests/InjectionScannerUnitTest.cs
@@ -45,7 +45,7 @@ public class InjectionScannerUnitTest
         var metadata = InjectionScanner.CollectMetadata(assemblies);
         var typeMetadata = metadata[typeof(FirstAssembly1)];
 
-        typeMetadata.members.Should().HaveCount(6);
+        typeMetadata.members.Should().HaveCount(7);
         typeMetadata.methods.Should().HaveCount(3);
         typeMetadata.nestedInjections.Should().HaveCount(3);
     }

--- a/Godot.DependencyInjection.Core/Scanning/InjectableScanner.cs
+++ b/Godot.DependencyInjection.Core/Scanning/InjectableScanner.cs
@@ -126,7 +126,9 @@ internal static class InjectionScanner
                 var memberMetadata = MemberMetadataFactory.CreateMemberMetadata(properties[i].PropertyType, properties[i].SetValue, memberAttribute.IsRequired);
                 membersMetadata.Add(memberMetadata);
             }
-            else if (nestedAttribute is not null)
+
+
+            if (nestedAttribute is not null)
             {
                 var nestedMetadata = new NestedInjectionMetadata(properties[i].PropertyType, properties[i].GetValue);
                 nestedInjectionMetadata.Add(nestedMetadata);
@@ -143,7 +145,7 @@ internal static class InjectionScanner
                 var memberMetadata = MemberMetadataFactory.CreateMemberMetadata(fields[i].FieldType, fields[i].SetValue, memberAttribute.IsRequired);
                 membersMetadata.Add(memberMetadata);
             }
-            else if (nestedAttribute is not null)
+            if (nestedAttribute is not null)
             {
                 var nestedMetadata = new NestedInjectionMetadata(fields[i].FieldType, fields[i].GetValue);
                 nestedInjectionMetadata.Add(nestedMetadata);
@@ -167,7 +169,7 @@ internal static class InjectionScanner
                 var memberMetadata = MemberMetadataFactory.CreateMemberMetadata(properties[i].PropertyType, properties[i].SetValue, memberAttribute.IsRequired);
                 membersMetadata.Add(memberMetadata);
             }
-            else if (nestedAttribute is not null)
+            if (nestedAttribute is not null)
             {
                 var nestedMetadata = new NestedInjectionMetadata(properties[i].PropertyType, properties[i].GetValue);
                 nestedInjectionMetadata.Add(nestedMetadata);
@@ -192,7 +194,7 @@ internal static class InjectionScanner
                 var memberMetadata = MemberMetadataFactory.CreateMemberMetadata(fields[i].FieldType, fields[i].SetValue, memberAttribute.IsRequired);
                 membersMetadata.Add(memberMetadata);
             }
-            else if (nestedAttribute is not null)
+            if (nestedAttribute is not null)
             {
                 var nestedMetadata = new NestedInjectionMetadata(fields[i].FieldType, fields[i].GetValue);
                 nestedInjectionMetadata.Add(nestedMetadata);


### PR DESCRIPTION
 Maybe we can also optimize the InjectableScanner. 
 I dont look in to deep but some code should be outsourced the loops.
 
What did you have in mind by saying
> I'm currently in the process of reevaluating the architecture and scope of the project

One thought of me was, maybe we do not need InjectMember just do both when the Inject Attribute is set.  